### PR TITLE
"Symbol not found: _clock_gettime" error on the runtime fixed on OS X prior to 10.12 when Netty is compiled on OS X 10.12

### DIFF
--- a/transport-native-unix-common/src/main/c/netty_unix_util.c
+++ b/transport-native-unix-common/src/main/c/netty_unix_util.c
@@ -93,9 +93,11 @@ int netty_unix_util_clock_gettime(clockid_t clockId, struct timespec* tp) {
 #ifdef NETTY_USE_MACH_INSTEAD_OF_CLOCK
   uint64_t timeNs;
   switch (clockId) {
+#ifdef CLOCK_MONOTONIC_COARSE
   case CLOCK_MONOTONIC_COARSE:
     timeNs = mach_approximate_time();
     break;
+#endif
   case CLOCK_MONOTONIC:
     timeNs = mach_absolute_time();
     break;

--- a/transport-native-unix-common/src/main/c/netty_unix_util.h
+++ b/transport-native-unix-common/src/main/c/netty_unix_util.h
@@ -20,8 +20,10 @@
 #include <jni.h>
 #include <time.h>
 
-#if defined(__MACH__) && !defined(CLOCK_REALTIME)
+#ifdef __MACH__
 #define NETTY_USE_MACH_INSTEAD_OF_CLOCK
+
+#ifndef CLOCK_REALTIME
 
 typedef int clockid_t;
 
@@ -32,6 +34,8 @@ typedef int clockid_t;
 #ifndef CLOCK_MONOTONIC_COARSE
 #define CLOCK_MONOTONIC_COARSE 2
 #endif
+
+#endif /* CLOCK_REALTIME */
 
 #endif /* __MACH__ */
 


### PR DESCRIPTION
`mach_approximate_time()` and `mach_absolute_time()` functions must be used at the compile time because `clock_gettime()` is not supported on OS X prior to 10.12 and Netty must not be compiled using it even on OS X 10.12.